### PR TITLE
Enhance CloudStorage API: Add conditions and validation logic

### DIFF
--- a/api/v1alpha1/cloudstorage_types.go
+++ b/api/v1alpha1/cloudstorage_types.go
@@ -60,10 +60,29 @@ type CloudStorageStatus struct {
 	// Name is the name requested for the bucket (aws, gcp) or container (azure)
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Name string `json:"name"`
-	// LastSyncTimestamp is the last time the contents of the CloudStorage was synced
+	// LastSyncTimestamp represents the last time the CloudStorage resource was successfully reconciled.
+	// This timestamp is updated when the controller verifies the bucket/container exists in the cloud provider
+	// or successfully creates it. The field is set for all supported providers (AWS, Azure, GCP).
 	// +operator-sdk:csv:customresourcedefinitions:type=status,displayName="LastSyncTimestamp"
 	LastSynced *metav1.Time `json:"lastSyncTimestamp,omitempty"`
+	// Conditions represent the latest available observations of the CloudStorage's state.
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
+
+// CloudStorage Conditions
+const (
+	// ConditionCloudStorageReconciled indicates whether the CloudStorage resource has been successfully reconciled
+	ConditionCloudStorageReconciled = "Reconciled"
+	// CloudStorageReconciledReasonComplete indicates the CloudStorage reconciliation completed successfully
+	CloudStorageReconciledReasonComplete = "Complete"
+	// CloudStorageReconciledReasonError indicates the CloudStorage reconciliation failed with an error
+	CloudStorageReconciledReasonError = "Error"
+	// CloudStorageReconciledReasonValidationFailed indicates the CloudStorage validation failed
+	CloudStorageReconciledReasonValidationFailed = "ValidationFailed"
+	// CloudStorageReconcileCompleteMessage indicates the CloudStorage reconciliation is complete
+	CloudStorageReconcileCompleteMessage = "CloudStorage reconcile complete"
+)
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/v1alpha1/cloudstorage_types.go
+++ b/api/v1alpha1/cloudstorage_types.go
@@ -67,6 +67,8 @@ type CloudStorageStatus struct {
 	LastSynced *metav1.Time `json:"lastSyncTimestamp,omitempty"`
 	// Conditions represent the latest available observations of the CloudStorage's state.
 	// +operator-sdk:csv:customresourcedefinitions:type=status
+	// +listType=map
+	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -24,8 +24,8 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/nodeagent"
 	"github.com/vmware-tanzu/velero/pkg/util/kube"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	timex "time"
 )
@@ -196,12 +196,12 @@ func (in *CloudStorageLocation) DeepCopyInto(out *CloudStorageLocation) {
 	}
 	if in.Credential != nil {
 		in, out := &in.Credential, &out.Credential
-		*out = new(v1.SecretKeySelector)
+		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.BackupSyncPeriod != nil {
 		in, out := &in.BackupSyncPeriod, &out.BackupSyncPeriod
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.CACert != nil {
@@ -262,6 +262,13 @@ func (in *CloudStorageStatus) DeepCopyInto(out *CloudStorageStatus) {
 	if in.LastSynced != nil {
 		in, out := &in.LastSynced, &out.LastSynced
 		*out = (*in).DeepCopy()
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 
@@ -450,7 +457,7 @@ func (in *DataProtectionApplicationSpec) DeepCopyInto(out *DataProtectionApplica
 	}
 	if in.ImagePullPolicy != nil {
 		in, out := &in.ImagePullPolicy, &out.ImagePullPolicy
-		*out = new(v1.PullPolicy)
+		*out = new(corev1.PullPolicy)
 		**out = **in
 	}
 	if in.NonAdmin != nil {
@@ -475,7 +482,7 @@ func (in *DataProtectionApplicationStatus) DeepCopyInto(out *DataProtectionAppli
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]metav1.Condition, len(*in))
+		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -620,18 +627,18 @@ func (in *EnforceBackupStorageLocationSpec) DeepCopyInto(out *EnforceBackupStora
 	}
 	if in.Credential != nil {
 		in, out := &in.Credential, &out.Credential
-		*out = new(v1.SecretKeySelector)
+		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
 	in.StorageType.DeepCopyInto(&out.StorageType)
 	if in.BackupSyncPeriod != nil {
 		in, out := &in.BackupSyncPeriod, &out.BackupSyncPeriod
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ValidationFrequency != nil {
 		in, out := &in.ValidationFrequency, &out.ValidationFrequency
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 }
@@ -841,12 +848,12 @@ func (in *NodeAgentConfig) DeepCopyInto(out *NodeAgentConfig) {
 	in.NodeAgentCommonFields.DeepCopyInto(&out.NodeAgentCommonFields)
 	if in.DataMoverPrepareTimeout != nil {
 		in, out := &in.DataMoverPrepareTimeout, &out.DataMoverPrepareTimeout
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.ResourceTimeout != nil {
 		in, out := &in.ResourceTimeout, &out.ResourceTimeout
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	in.NodeAgentConfigMapSettings.DeepCopyInto(&out.NodeAgentConfigMapSettings)
@@ -941,12 +948,12 @@ func (in *NonAdmin) DeepCopyInto(out *NonAdmin) {
 	}
 	if in.GarbageCollectionPeriod != nil {
 		in, out := &in.GarbageCollectionPeriod, &out.GarbageCollectionPeriod
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.BackupSyncPeriod != nil {
 		in, out := &in.BackupSyncPeriod, &out.BackupSyncPeriod
-		*out = new(metav1.Duration)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 }
@@ -1000,7 +1007,7 @@ func (in *PodConfig) DeepCopyInto(out *PodConfig) {
 	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
-		*out = make([]v1.Toleration, len(*in))
+		*out = make([]corev1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -1008,7 +1015,7 @@ func (in *PodConfig) DeepCopyInto(out *PodConfig) {
 	in.ResourceAllocations.DeepCopyInto(&out.ResourceAllocations)
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
-		*out = make([]v1.EnvVar, len(*in))
+		*out = make([]corev1.EnvVar, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/bundle/manifests/oadp-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/oadp-operator.clusterserviceversion.yaml
@@ -394,8 +394,14 @@ spec:
       kind: CloudStorage
       name: cloudstorages.oadp.openshift.io
       statusDescriptors:
-      - description: LastSyncTimestamp is the last time the contents of the CloudStorage
-          was synced
+      - description: Conditions represent the latest available observations of the
+          CloudStorage's state.
+        displayName: Conditions
+        path: conditions
+      - description: LastSyncTimestamp represents the last time the CloudStorage resource
+          was successfully reconciled. This timestamp is updated when the controller
+          verifies the bucket/container exists in the cloud provider or successfully
+          creates it. The field is set for all supported providers (AWS, Azure, GCP).
         displayName: LastSyncTimestamp
         path: lastSyncTimestamp
       - description: Name is the name requested for the bucket (aws, gcp) or container

--- a/bundle/manifests/oadp.openshift.io_cloudstorages.yaml
+++ b/bundle/manifests/oadp.openshift.io_cloudstorages.yaml
@@ -157,6 +157,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               lastSyncTimestamp:
                 description: |-
                   LastSyncTimestamp represents the last time the CloudStorage resource was successfully reconciled.

--- a/bundle/manifests/oadp.openshift.io_cloudstorages.yaml
+++ b/bundle/manifests/oadp.openshift.io_cloudstorages.yaml
@@ -99,9 +99,69 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the CloudStorage's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               lastSyncTimestamp:
-                description: LastSyncTimestamp is the last time the contents of the
-                  CloudStorage was synced
+                description: |-
+                  LastSyncTimestamp represents the last time the CloudStorage resource was successfully reconciled.
+                  This timestamp is updated when the controller verifies the bucket/container exists in the cloud provider
+                  or successfully creates it. The field is set for all supported providers (AWS, Azure, GCP).
                 format: date-time
                 type: string
               name:

--- a/config/crd/bases/oadp.openshift.io_cloudstorages.yaml
+++ b/config/crd/bases/oadp.openshift.io_cloudstorages.yaml
@@ -157,6 +157,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               lastSyncTimestamp:
                 description: |-
                   LastSyncTimestamp represents the last time the CloudStorage resource was successfully reconciled.

--- a/config/crd/bases/oadp.openshift.io_cloudstorages.yaml
+++ b/config/crd/bases/oadp.openshift.io_cloudstorages.yaml
@@ -99,9 +99,69 @@ spec:
             type: object
           status:
             properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the CloudStorage's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               lastSyncTimestamp:
-                description: LastSyncTimestamp is the last time the contents of the
-                  CloudStorage was synced
+                description: |-
+                  LastSyncTimestamp represents the last time the CloudStorage resource was successfully reconciled.
+                  This timestamp is updated when the controller verifies the bucket/container exists in the cloud provider
+                  or successfully creates it. The field is set for all supported providers (AWS, Azure, GCP).
                 format: date-time
                 type: string
               name:

--- a/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/oadp-operator.clusterserviceversion.yaml
@@ -403,8 +403,14 @@ spec:
       kind: CloudStorage
       name: cloudstorages.oadp.openshift.io
       statusDescriptors:
-      - description: LastSyncTimestamp is the last time the contents of the CloudStorage
-          was synced
+      - description: Conditions represent the latest available observations of the
+          CloudStorage's state.
+        displayName: Conditions
+        path: conditions
+      - description: LastSyncTimestamp represents the last time the CloudStorage resource
+          was successfully reconciled. This timestamp is updated when the controller
+          verifies the bucket/container exists in the cloud provider or successfully
+          creates it. The field is set for all supported providers (AWS, Azure, GCP).
         displayName: LastSyncTimestamp
         path: lastSyncTimestamp
       - description: Name is the name requested for the bucket (aws, gcp) or container

--- a/internal/controller/cloudstorage_controller.go
+++ b/internal/controller/cloudstorage_controller.go
@@ -20,11 +20,13 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -71,6 +73,24 @@ func (b CloudStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err := b.Client.Get(ctx, req.NamespacedName, &bucket); err != nil {
 		logger.Error(err, "unable to fetch bucket CR")
 		return result, nil
+	}
+
+	// Validate CloudStorage configuration
+	if err := b.ValidateCloudStorage(&bucket); err != nil {
+		logger.Error(err, "CloudStorage validation failed")
+		apimeta.SetStatusCondition(&bucket.Status.Conditions,
+			metav1.Condition{
+				Type:    oadpv1alpha1.ConditionCloudStorageReconciled,
+				Status:  metav1.ConditionFalse,
+				Reason:  oadpv1alpha1.CloudStorageReconciledReasonValidationFailed,
+				Message: fmt.Sprintf("Validation failed: %v", err),
+			},
+		)
+		b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "ValidationFailed", fmt.Sprintf("CloudStorage validation failed: %v", err))
+		if err := b.Client.Status().Update(ctx, &bucket); err != nil {
+			logger.Error(err, "Failed to update CloudStorage status")
+		}
+		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 
 	// Add finalizer if none exists and object is not being deleted.
@@ -142,11 +162,33 @@ func (b CloudStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		if !created {
 			logger.Info("unable to create object bucket")
 			b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "BucketNotCreated", fmt.Sprintf("unable to create bucket: %v", err))
+			apimeta.SetStatusCondition(&bucket.Status.Conditions,
+				metav1.Condition{
+					Type:    oadpv1alpha1.ConditionCloudStorageReconciled,
+					Status:  metav1.ConditionFalse,
+					Reason:  oadpv1alpha1.CloudStorageReconciledReasonError,
+					Message: fmt.Sprintf("Unable to create bucket: %v", err),
+				},
+			)
+			if statusErr := b.Client.Status().Update(ctx, &bucket); statusErr != nil {
+				logger.Error(statusErr, "Failed to update CloudStorage status after bucket creation failure")
+			}
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
 		if err != nil {
 			//TODO: LOG/EVENT THE MESSAGE
 			logger.Error(err, "Error while creating event")
+			apimeta.SetStatusCondition(&bucket.Status.Conditions,
+				metav1.Condition{
+					Type:    oadpv1alpha1.ConditionCloudStorageReconciled,
+					Status:  metav1.ConditionFalse,
+					Reason:  oadpv1alpha1.CloudStorageReconciledReasonError,
+					Message: fmt.Sprintf("Error creating bucket: %v", err),
+				},
+			)
+			if statusErr := b.Client.Status().Update(ctx, &bucket); statusErr != nil {
+				logger.Error(statusErr, "Failed to update CloudStorage status after error")
+			}
 			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
 		b.EventRecorder.Event(&bucket, corev1.EventTypeNormal, "BucketCreated", fmt.Sprintf("bucket %v has been created", bucket.Spec.Name))
@@ -155,14 +197,38 @@ func (b CloudStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Bucket may be created but something else went wrong.
 		logger.Error(err, "unable to determine if bucket exists.")
 		b.EventRecorder.Event(&bucket, corev1.EventTypeWarning, "BucketNotFound", fmt.Sprintf("unable to find bucket: %v", err))
+		apimeta.SetStatusCondition(&bucket.Status.Conditions,
+			metav1.Condition{
+				Type:    oadpv1alpha1.ConditionCloudStorageReconciled,
+				Status:  metav1.ConditionFalse,
+				Reason:  oadpv1alpha1.CloudStorageReconciledReasonError,
+				Message: fmt.Sprintf("Unable to determine if bucket exists: %v", err),
+			},
+		)
+		if statusErr := b.Client.Status().Update(ctx, &bucket); statusErr != nil {
+			logger.Error(statusErr, "Failed to update CloudStorage status after bucket existence check failure")
+		}
 		return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 	}
 
 	// Update status with updated value
 	bucket.Status.LastSynced = &metav1.Time{Time: time.Now()}
 	bucket.Status.Name = bucket.Spec.Name
+	
+	// Set success condition
+	apimeta.SetStatusCondition(&bucket.Status.Conditions,
+		metav1.Condition{
+			Type:    oadpv1alpha1.ConditionCloudStorageReconciled,
+			Status:  metav1.ConditionTrue,
+			Reason:  oadpv1alpha1.CloudStorageReconciledReasonComplete,
+			Message: oadpv1alpha1.CloudStorageReconcileCompleteMessage,
+		},
+	)
 
-	b.Client.Status().Update(ctx, &bucket)
+	if err := b.Client.Status().Update(ctx, &bucket); err != nil {
+		logger.Error(err, "Failed to update CloudStorage status")
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -240,3 +306,110 @@ func (b *CloudStorageReconciler) WaitForSecret(namespace, name string) (*corev1.
 
 	return &secret, nil
 }
+
+// ValidateCloudStorage validates the CloudStorage configuration based on the provider
+func (b *CloudStorageReconciler) ValidateCloudStorage(bucket *oadpv1alpha1.CloudStorage) error {
+	// Validate that a provider is specified
+	if bucket.Spec.Provider == "" {
+		return fmt.Errorf("provider must be specified")
+	}
+
+	// Validate that a bucket/container name is specified
+	if bucket.Spec.Name == "" {
+		return fmt.Errorf("bucket/container name must be specified")
+	}
+
+	// Provider-specific validation
+	switch bucket.Spec.Provider {
+	case oadpv1alpha1.AWSBucketProvider:
+		// AWS requires region
+		if bucket.Spec.Region == "" {
+			return fmt.Errorf("AWS provider requires region to be specified")
+		}
+		// Check if credentials secret exists
+		if bucket.Spec.CreationSecret.Name != "" {
+			secret := &corev1.Secret{}
+			err := b.Client.Get(context.Background(), types.NamespacedName{
+				Name:      bucket.Spec.CreationSecret.Name,
+				Namespace: bucket.Namespace,
+			}, secret)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return fmt.Errorf("AWS credentials secret %s not found in namespace %s", bucket.Spec.CreationSecret.Name, bucket.Namespace)
+				}
+				return fmt.Errorf("error fetching AWS credentials secret: %v", err)
+			}
+			// Check for required fields in secret
+			if _, hasAccessKey := secret.Data["AWS_ACCESS_KEY_ID"]; !hasAccessKey {
+				if _, hasCloudCreds := secret.Data["cloud"]; !hasCloudCreds {
+					return fmt.Errorf("AWS credentials secret must contain AWS_ACCESS_KEY_ID or cloud field")
+				}
+			}
+		}
+
+	case oadpv1alpha1.AzureBucketProvider:
+		// Azure requires storage account
+		if bucket.Spec.Name == "" {
+			return fmt.Errorf("Azure provider requires container name to be specified")
+		}
+		// Check if credentials secret exists
+		if bucket.Spec.CreationSecret.Name != "" {
+			secret := &corev1.Secret{}
+			err := b.Client.Get(context.Background(), types.NamespacedName{
+				Name:      bucket.Spec.CreationSecret.Name,
+				Namespace: bucket.Namespace,
+			}, secret)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return fmt.Errorf("Azure credentials secret %s not found in namespace %s", bucket.Spec.CreationSecret.Name, bucket.Namespace)
+				}
+				return fmt.Errorf("error fetching Azure credentials secret: %v", err)
+			}
+			// Check for required fields based on authentication method
+			hasStorageAccount := false
+			if _, ok := secret.Data["AZURE_STORAGE_ACCOUNT_NAME"]; ok {
+				hasStorageAccount = true
+			}
+			if _, ok := secret.Data["storageAccount"]; ok {
+				hasStorageAccount = true
+			}
+			if !hasStorageAccount {
+				// Check if it's in the azurekey field (STS format)
+				if azureKey, ok := secret.Data["azurekey"]; ok {
+					keyStr := string(azureKey)
+					if !strings.Contains(keyStr, "AZURE_STORAGE_ACCOUNT") {
+						return fmt.Errorf("Azure credentials must specify storage account name")
+					}
+				} else {
+					return fmt.Errorf("Azure credentials must specify storage account name")
+				}
+			}
+		}
+
+	case oadpv1alpha1.GCPBucketProvider:
+		// GCP validation
+		if bucket.Spec.CreationSecret.Name != "" {
+			secret := &corev1.Secret{}
+			err := b.Client.Get(context.Background(), types.NamespacedName{
+				Name:      bucket.Spec.CreationSecret.Name,
+				Namespace: bucket.Namespace,
+			}, secret)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return fmt.Errorf("GCP credentials secret %s not found in namespace %s", bucket.Spec.CreationSecret.Name, bucket.Namespace)
+				}
+				return fmt.Errorf("error fetching GCP credentials secret: %v", err)
+			}
+			// Check for required fields in secret
+			if _, hasCloudCreds := secret.Data["cloud"]; !hasCloudCreds {
+				return fmt.Errorf("GCP credentials secret must contain cloud field with service account JSON")
+			}
+		}
+
+	default:
+		return fmt.Errorf("unsupported provider: %s", bucket.Spec.Provider)
+	}
+
+	return nil
+}
+


### PR DESCRIPTION
- Introduced Conditions field in CloudStorageStatus to track the state of the resource.
- Updated LastSyncTimestamp description for clarity.
- Enhanced CloudStorage CRD and CSV with new status descriptors.
- Implemented validation logic for CloudStorage configuration in the controller.

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CloudStorage now exposes status.conditions with standardized reconciliation states.
  - Operator UI shows Conditions, LastSyncTimestamp, and Name in CloudStorage status.
  - Provider-aware validation for AWS/Azure/GCP with clear status updates and warning events.

- Documentation
  - Clarified LastSyncTimestamp to represent the last successful reconciliation across providers.

- Bug Fixes
  - More reliable status reporting during reconciliation, including explicit success, error, and validation-failed reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->