### PR TITLE
Optimize edge-catalog github action workflow

### DIFF
--- a/.github/workflows/edge-catalog.yml
+++ b/.github/workflows/edge-catalog.yml
@@ -339,7 +339,7 @@ jobs:
           BUNDLE_IMGS=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ steps.git-ref.outputs.GIT_REF }} \
           CATALOG_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }}
     - name: add bundle to ${{ steps.build-tag.outputs.BUILD_TAG }} existing catalog build and push
-      if: ${{ steps.catalog-build-tag-exist.outcome == 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' && steps.catalog-build-tag-exist.outcome == 'success' }}
       id: add-to-existing-catalog
       continue-on-error: true
       run: |
@@ -353,7 +353,7 @@ jobs:
           CATALOG_BASE_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} \
           CATALOG_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }}
     - name: if existing fail, add bundle to new ${{ steps.build-tag.outputs.BUILD_TAG }} catalog build and push
-      if: ${{ steps.catalog-build-tag-exist.outcome != 'success'}}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' && steps.catalog-build-tag-exist.outcome != 'success'}}
       run: |
         make catalog-build-replaces catalog-push \
           OPM=/usr/local/bin/opm \

--- a/.github/workflows/edge-catalog.yml
+++ b/.github/workflows/edge-catalog.yml
@@ -108,16 +108,20 @@ jobs:
       run: echo "BUILD_TAG=$(cat /tmp/tag)" >> $GITHUB_OUTPUT
     - name: echo build-tag
       run: echo ${{ steps.build-tag.outputs.BUILD_TAG }}
-    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} exists
+    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} can be pulled
       id: catalog-git-ref-exist
       if: ${{ github.event_name != 'workflow_dispatch' }}
       continue-on-error: true
-      run: docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} > /dev/null
-    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} exists
+      env:
+        GIT_REF_TAG: ${{ steps.git-ref.outputs.GIT_REF }}
+      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${GIT_REF_TAG}
+    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} can be pulled
       id: catalog-build-tag-exist
       if: ${{ github.event_name != 'workflow_dispatch' }}
       continue-on-error: true
-      run: docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} > /dev/null
+      env:
+        BUILD_TAG_VAR: ${{ steps.build-tag.outputs.BUILD_TAG }}
+      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${BUILD_TAG_VAR}
     - name: get year month date hour minutes
       id: dateversion
       run: echo "YMdHM=$(date -u +%Y%m%d%H%M)" >> $GITHUB_OUTPUT

--- a/.github/workflows/edge-catalog.yml
+++ b/.github/workflows/edge-catalog.yml
@@ -143,13 +143,13 @@ jobs:
     # Install the cosign tool except on PR
     # https://github.com/sigstore/cosign-installer
     - uses: actions/setup-go@v6
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success' }}
       with:
         go-version: '^1.25.0' # The Go version to download (if necessary) and use.
     - run: go version
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success' }}
     - name: install operator-sdk opm
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success' }}
       run: |
         export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
         export OS=$(uname | awk '{print tolower($0)}')
@@ -161,29 +161,29 @@ jobs:
         curl -LO ${OPM_DL_URL}/${OS}-${ARCH}-opm
         chmod +x ${OS}-${ARCH}-opm && sudo mv ${OS}-${ARCH}-opm /usr/local/bin/opm
     - name: Install cosign
-      if: ${{ github.event_name != 'pull_request' && steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ github.event_name != 'pull_request' && (steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success') }}
       uses: sigstore/cosign-installer@v3
       with:
         cosign-release: 'v2.4.1'
     # Workaround: https://github.com/docker/build-push-action/issues/461
     - name: Set up QEMU
       id: qemu
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success' }}
       uses: docker/setup-qemu-action@v4
       with:
         image: tonistiigi/binfmt:latest
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
     - name: Setup Docker buildx
       id: buildx
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success' }}
       uses: docker/setup-buildx-action@v4
     # Login against a Docker registry except on PR
     # https://github.com/docker/login-action
     - name: Available platforms
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success' }}
       run: echo ${{ steps.buildx.outputs.platforms }}
     - name: Log into registry ${{ env.REGISTRY }}
-      if: ${{ github.event_name != 'pull_request' && steps.catalog-git-ref-exist.outcome != 'success' }}
+      if: ${{ github.event_name != 'pull_request' && (steps.catalog-git-ref-exist.outcome != 'success' || steps.catalog-build-tag-exist.outcome != 'success') }}
       uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
@@ -335,7 +335,7 @@ jobs:
           BUNDLE_IMGS=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ steps.git-ref.outputs.GIT_REF }} \
           CATALOG_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }}
     - name: add bundle to ${{ steps.build-tag.outputs.BUILD_TAG }} existing catalog build and push
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' && steps.catalog-build-tag-exist.outcome == 'success' }}
+      if: ${{ steps.catalog-build-tag-exist.outcome == 'success' }}
       id: add-to-existing-catalog
       continue-on-error: true
       run: |
@@ -349,7 +349,7 @@ jobs:
           CATALOG_BASE_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} \
           CATALOG_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }}
     - name: if existing fail, add bundle to new ${{ steps.build-tag.outputs.BUILD_TAG }} catalog build and push
-      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' && steps.catalog-build-tag-exist.outcome != 'success'}}
+      if: ${{ steps.catalog-build-tag-exist.outcome != 'success'}}
       run: |
         make catalog-build-replaces catalog-push \
           OPM=/usr/local/bin/opm \

--- a/.github/workflows/edge-catalog.yml
+++ b/.github/workflows/edge-catalog.yml
@@ -108,6 +108,16 @@ jobs:
       run: echo "BUILD_TAG=$(cat /tmp/tag)" >> $GITHUB_OUTPUT
     - name: echo build-tag
       run: echo ${{ steps.build-tag.outputs.BUILD_TAG }}
+    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} can be pulled
+      id: catalog-git-ref-exist
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      continue-on-error: true
+      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }}
+    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} can be pulled
+      id: catalog-build-tag-exist
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      continue-on-error: true
+      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }}
     - name: get year month date hour minutes
       id: dateversion
       run: echo "YMdHM=$(date -u +%Y%m%d%H%M)" >> $GITHUB_OUTPUT
@@ -133,10 +143,13 @@ jobs:
     # Install the cosign tool except on PR
     # https://github.com/sigstore/cosign-installer
     - uses: actions/setup-go@v6
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
       with:
         go-version: '^1.25.0' # The Go version to download (if necessary) and use.
     - run: go version
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
     - name: install operator-sdk opm
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
       run: |
         export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
         export OS=$(uname | awk '{print tolower($0)}')
@@ -148,39 +161,34 @@ jobs:
         curl -LO ${OPM_DL_URL}/${OS}-${ARCH}-opm
         chmod +x ${OS}-${ARCH}-opm && sudo mv ${OS}-${ARCH}-opm /usr/local/bin/opm
     - name: Install cosign
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name != 'pull_request' && steps.catalog-git-ref-exist.outcome != 'success' }}
       uses: sigstore/cosign-installer@v3
       with:
         cosign-release: 'v2.4.1'
     # Workaround: https://github.com/docker/build-push-action/issues/461
     - name: Set up QEMU
       id: qemu
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
       uses: docker/setup-qemu-action@v4
       with:
         image: tonistiigi/binfmt:latest
         platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
     - name: Setup Docker buildx
       id: buildx
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
       uses: docker/setup-buildx-action@v4
     # Login against a Docker registry except on PR
     # https://github.com/docker/login-action
     - name: Available platforms
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' }}
       run: echo ${{ steps.buildx.outputs.platforms }}
     - name: Log into registry ${{ env.REGISTRY }}
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name != 'pull_request' && steps.catalog-git-ref-exist.outcome != 'success' }}
       uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} can be pulled
-      id: catalog-git-ref-exist
-      continue-on-error: true
-      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }}
-    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} can be pulled
-      id: catalog-build-tag-exist
-      continue-on-error: true
-      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }}
     # Extract metadata (tags, labels) for Docker
     # https://github.com/docker/metadata-action
     - name: Extract Docker metadata
@@ -327,7 +335,7 @@ jobs:
           BUNDLE_IMGS=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-bundle:${{ steps.git-ref.outputs.GIT_REF }} \
           CATALOG_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }}
     - name: add bundle to ${{ steps.build-tag.outputs.BUILD_TAG }} existing catalog build and push
-      if: ${{ steps.catalog-build-tag-exist.outcome == 'success' }}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' && steps.catalog-build-tag-exist.outcome == 'success' }}
       id: add-to-existing-catalog
       continue-on-error: true
       run: |
@@ -341,7 +349,7 @@ jobs:
           CATALOG_BASE_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} \
           CATALOG_IMG=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }}
     - name: if existing fail, add bundle to new ${{ steps.build-tag.outputs.BUILD_TAG }} catalog build and push
-      if: ${{ steps.catalog-build-tag-exist.outcome != 'success'}}
+      if: ${{ steps.catalog-git-ref-exist.outcome != 'success' && steps.catalog-build-tag-exist.outcome != 'success'}}
       run: |
         make catalog-build-replaces catalog-push \
           OPM=/usr/local/bin/opm \

--- a/.github/workflows/edge-catalog.yml
+++ b/.github/workflows/edge-catalog.yml
@@ -108,16 +108,16 @@ jobs:
       run: echo "BUILD_TAG=$(cat /tmp/tag)" >> $GITHUB_OUTPUT
     - name: echo build-tag
       run: echo ${{ steps.build-tag.outputs.BUILD_TAG }}
-    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} can be pulled
+    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} exists
       id: catalog-git-ref-exist
       if: ${{ github.event_name != 'workflow_dispatch' }}
       continue-on-error: true
-      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }}
-    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} can be pulled
+      run: docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.git-ref.outputs.GIT_REF }} > /dev/null
+    - name: check ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} exists
       id: catalog-build-tag-exist
       if: ${{ github.event_name != 'workflow_dispatch' }}
       continue-on-error: true
-      run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }}
+      run: docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-catalog:${{ steps.build-tag.outputs.BUILD_TAG }} > /dev/null
     - name: get year month date hour minutes
       id: dateversion
       run: echo "YMdHM=$(date -u +%Y%m%d%H%M)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Identified redundant operations causing high cost of execution on gh actions in `edge-catalog.yml`. By re-ordering checking of existing catalog images before heavy tool downloads such as go and opm, and skipping image building conditionally, this reduces overhead across workflow jobs.

---
*PR created automatically by Jules for task [9190258603597766284](https://jules.google.com/task/9190258603597766284) started by @kaovilai*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the edge catalog automation to use tolerant checks to determine whether the relevant catalog image tags already exist.
  * Tooling setup, platform reporting, and registry-related steps are now gated based on those check outcomes to reduce unnecessary execution.
  * Cosign installation and registry login are further limited to specific event types to better match intended release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->